### PR TITLE
Bring artifacts up to date with DT part 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/invariant": "2.2.29",
-    "@types/relay-runtime": "^1.3.1",
     "immutable": "~3.7.6",
     "invariant": "2.2.2"
   },
@@ -32,8 +30,10 @@
   "devDependencies": {
     "@types/graphql": "^0.12.1",
     "@types/immutable": "3.8.7",
+    "@types/invariant": "2.2.29",
     "@types/jest": "^22.0.1",
     "@types/node": "8.5.7",
+    "@types/relay-runtime": "^1.3.1",
     "jest": "^22.1.4",
     "prettier": "^1.10.2",
     "relay-compiler": "https://github.com/alloy/relay/releases/download/v1.5.0-plugin.1/relay-compiler-1.5.0-plugin.1.tgz",

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -340,7 +340,7 @@ function createVisitor(options: TypeGeneratorOptions) {
           undefined,
           ts.createIntersectionTypeNode([
             ts.createTypeReferenceNode(_refType.name, undefined),
-            ts.createTypeReferenceNode("ConcreteFragment", undefined)
+            ts.createTypeReferenceNode("FragmentReference", undefined)
           ])
         );
         const baseType = selectionsToAST(selections, state, refTypeName);
@@ -352,7 +352,7 @@ function createVisitor(options: TypeGeneratorOptions) {
         return [
           ...getFragmentImports(state),
           ...getEnumDefinitions(state),
-          importTypes(["ConcreteFragment"], state.relayRuntimeModule),
+          importTypes(["FragmentReference"], state.relayRuntimeModule),
           _refType,
           refType,
           exportType(node.name, type)

--- a/src/TypeScriptGenerator.ts
+++ b/src/TypeScriptGenerator.ts
@@ -299,7 +299,10 @@ function createVisitor(options: TypeGeneratorOptions) {
           selectionsToAST(node.selections, state)
         );
         return [
-          ...getFragmentImports(state),
+          // TODO: This is disabled until TS 2.8 is released which has the features we need to properly support fragment
+          //       reference checking. See https://github.com/alloy/DefinitelyTyped/pull/1
+          //
+          // ...getFragmentImports(state),
           ...getEnumDefinitions(state),
           inputVariablesType,
           responseType
@@ -326,35 +329,39 @@ function createVisitor(options: TypeGeneratorOptions) {
           }
           return [selection];
         });
-        const refTypeName = getRefTypeName(node.name);
-        const _refType = ts.createEnumDeclaration(
-          undefined,
-          [ts.createToken(ts.SyntaxKind.ConstKeyword)],
-          ts.createIdentifier(`_${refTypeName}`),
-          []
-        );
-        const refType = ts.createTypeAliasDeclaration(
-          undefined,
-          [ts.createToken(ts.SyntaxKind.ExportKeyword)],
-          refTypeName,
-          undefined,
-          ts.createIntersectionTypeNode([
-            ts.createTypeReferenceNode(_refType.name, undefined),
-            ts.createTypeReferenceNode("FragmentReference", undefined)
-          ])
-        );
-        const baseType = selectionsToAST(selections, state, refTypeName);
+        // TODO: This is disabled until TS 2.8 is released which has the features we need to properly support fragment
+        //       reference checking. See https://github.com/alloy/DefinitelyTyped/pull/1
+        //
+        // const refTypeName = getRefTypeName(node.name);
+        // const _refType = ts.createEnumDeclaration(
+        //   undefined,
+        //   [ts.createToken(ts.SyntaxKind.ConstKeyword)],
+        //   ts.createIdentifier(`_${refTypeName}`),
+        //   []
+        // );
+        // const refType = ts.createTypeAliasDeclaration(
+        //   undefined,
+        //   [ts.createToken(ts.SyntaxKind.ExportKeyword)],
+        //   refTypeName,
+        //   undefined,
+        //   ts.createIntersectionTypeNode([
+        //     ts.createTypeReferenceNode(_refType.name, undefined),
+        //     ts.createTypeReferenceNode("FragmentReference", undefined)
+        //   ])
+        // );
+        // const baseType = selectionsToAST(selections, state, refTypeName);
+        const baseType = selectionsToAST(selections, state);
         const type = isPlural(node)
           ? ts.createTypeReferenceNode(ts.createIdentifier("ReadonlyArray"), [
               baseType
             ])
           : baseType;
         return [
-          ...getFragmentImports(state),
+          // ...getFragmentImports(state),
           ...getEnumDefinitions(state),
-          importTypes(["FragmentReference"], state.relayRuntimeModule),
-          _refType,
-          refType,
+          // importTypes(["FragmentReference"], state.relayRuntimeModule),
+          // _refType,
+          // refType,
           exportType(node.name, type)
         ];
       },
@@ -465,11 +472,14 @@ function groupRefs(props: Selection[]): Selection[] {
         )
       )
     );
-    result.push({
-      key: " $fragmentRefs",
-      conditional: false,
-      value
-    });
+    // TODO: This is disabled until TS 2.8 is released which has the features we need to properly support fragment
+    //       reference checking. See https://github.com/alloy/DefinitelyTyped/pull/1
+    //
+    // result.push({
+    //   key: " $fragmentRefs",
+    //   conditional: false,
+    //   value
+    // });
   }
   return result;
 }

--- a/src/formatGeneratedModule.ts
+++ b/src/formatGeneratedModule.ts
@@ -11,7 +11,7 @@ export const formatGeneratedModule: FormatModule = ({
   sourceHash
 }) => {
   const documentTypeImport = documentType
-    ? `import { ${documentType} } from '${relayRuntimeModule}';`
+    ? `import { ${documentType} } from "${relayRuntimeModule}";`
     : "";
   const docTextComment = docText ? "\n/*\n" + docText.trim() + "\n*/\n" : "";
   return `/* tslint:disable */

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -13,20 +13,20 @@ fragment NestedCondition on Node {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _ConditionField$ref {
 }
-export type ConditionField$ref = _ConditionField$ref & ConcreteFragment;
+export type ConditionField$ref = _ConditionField$ref & FragmentReference;
 export type ConditionField = {
     readonly id?: string;
     readonly " $refType": ConditionField$ref;
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _NestedCondition$ref {
 }
-export type NestedCondition$ref = _NestedCondition$ref & ConcreteFragment;
+export type NestedCondition$ref = _NestedCondition$ref & FragmentReference;
 export type NestedCondition = {
     readonly id?: string;
     readonly " $refType": NestedCondition$ref;
@@ -70,10 +70,10 @@ type OtherFragment$ref = any;
 type PictureFragment$ref = any;
 type UserFrag1$ref = any;
 type UserFrag2$ref = any;
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _FragmentSpread$ref {
 }
-export type FragmentSpread$ref = _FragmentSpread$ref & ConcreteFragment;
+export type FragmentSpread$ref = _FragmentSpread$ref & FragmentReference;
 export type FragmentSpread = {
     readonly id: string;
     readonly justFrag: ({
@@ -89,10 +89,10 @@ export type FragmentSpread = {
 
 
 type PageFragment$ref = any;
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _ConcreateTypes$ref {
 }
-export type ConcreateTypes$ref = _ConcreateTypes$ref & ConcreteFragment;
+export type ConcreateTypes$ref = _ConcreateTypes$ref & FragmentReference;
 export type ConcreateTypes = {
     readonly actor: ({
         readonly __typename: "Page";
@@ -175,10 +175,10 @@ fragment InlineFragmentKitchenSink on Story {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _InlineFragment$ref {
 }
-export type InlineFragment$ref = _InlineFragment$ref & ConcreteFragment;
+export type InlineFragment$ref = _InlineFragment$ref & FragmentReference;
 export type InlineFragment = {
     readonly id: string;
     readonly name?: string | null;
@@ -189,10 +189,10 @@ export type InlineFragment = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _InlineFragmentWithOverlappingFields$ref {
 }
-export type InlineFragmentWithOverlappingFields$ref = _InlineFragmentWithOverlappingFields$ref & ConcreteFragment;
+export type InlineFragmentWithOverlappingFields$ref = _InlineFragmentWithOverlappingFields$ref & FragmentReference;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: ({
         readonly id: string;
@@ -206,10 +206,10 @@ export type InlineFragmentWithOverlappingFields = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _InlineFragmentConditionalID$ref {
 }
-export type InlineFragmentConditionalID$ref = _InlineFragmentConditionalID$ref & ConcreteFragment;
+export type InlineFragmentConditionalID$ref = _InlineFragmentConditionalID$ref & FragmentReference;
 export type InlineFragmentConditionalID = {
     readonly id?: string;
     readonly name?: string | null;
@@ -218,10 +218,10 @@ export type InlineFragmentConditionalID = {
 
 
 type SomeFragment$ref = any;
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _InlineFragmentKitchenSink$ref {
 }
-export type InlineFragmentKitchenSink$ref = _InlineFragmentKitchenSink$ref & ConcreteFragment;
+export type InlineFragmentKitchenSink$ref = _InlineFragmentKitchenSink$ref & FragmentReference;
 export type InlineFragmentKitchenSink = {
     readonly actor: ({
         readonly id: string;
@@ -269,10 +269,10 @@ query UnionTypeTest {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _LinkedField$ref {
 }
-export type LinkedField$ref = _LinkedField$ref & ConcreteFragment;
+export type LinkedField$ref = _LinkedField$ref & FragmentReference;
 export type LinkedField = {
     readonly profilePicture: ({
         readonly uri: string | null;
@@ -382,10 +382,10 @@ fragment PluralFragment on Node @relay(plural: true) {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _PluralFragment$ref {
 }
-export type PluralFragment$ref = _PluralFragment$ref & ConcreteFragment;
+export type PluralFragment$ref = _PluralFragment$ref & FragmentReference;
 export type PluralFragment = ReadonlyArray<{
         readonly id: string;
         readonly " $refType": PluralFragment$ref;
@@ -432,10 +432,10 @@ export type ExampleQueryResponse = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _ExampleFragment$ref {
 }
-export type ExampleFragment$ref = _ExampleFragment$ref & ConcreteFragment;
+export type ExampleFragment$ref = _ExampleFragment$ref & FragmentReference;
 export type ExampleFragment = {
     readonly id: string;
     readonly " $refType": ExampleFragment$ref;
@@ -491,10 +491,10 @@ fragment ScalarField on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _ScalarField$ref {
 }
-export type ScalarField$ref = _ScalarField$ref & ConcreteFragment;
+export type ScalarField$ref = _ScalarField$ref & FragmentReference;
 export type ScalarField = {
     readonly id: string;
     readonly name: string | null;
@@ -576,10 +576,10 @@ fragment TypenameWithCommonSelections on Actor {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameInside$ref {
 }
-export type TypenameInside$ref = _TypenameInside$ref & ConcreteFragment;
+export type TypenameInside$ref = _TypenameInside$ref & FragmentReference;
 export type TypenameInside = {
     readonly __typename: "User";
     readonly firstName: string | null;
@@ -596,10 +596,10 @@ export type TypenameInside = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameOutside$ref {
 }
-export type TypenameOutside$ref = _TypenameOutside$ref & ConcreteFragment;
+export type TypenameOutside$ref = _TypenameOutside$ref & FragmentReference;
 export type TypenameOutside = {
     readonly __typename: "User";
     readonly firstName: string | null;
@@ -616,10 +616,10 @@ export type TypenameOutside = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameOutsideWithAbstractType$ref {
 }
-export type TypenameOutsideWithAbstractType$ref = _TypenameOutsideWithAbstractType$ref & ConcreteFragment;
+export type TypenameOutsideWithAbstractType$ref = _TypenameOutsideWithAbstractType$ref & FragmentReference;
 export type TypenameOutsideWithAbstractType = {
     readonly __typename: string;
     readonly username?: string | null;
@@ -633,10 +633,10 @@ export type TypenameOutsideWithAbstractType = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameWithoutSpreads$ref {
 }
-export type TypenameWithoutSpreads$ref = _TypenameWithoutSpreads$ref & ConcreteFragment;
+export type TypenameWithoutSpreads$ref = _TypenameWithoutSpreads$ref & FragmentReference;
 export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
@@ -644,10 +644,10 @@ export type TypenameWithoutSpreads = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameWithoutSpreadsAbstractType$ref {
 }
-export type TypenameWithoutSpreadsAbstractType$ref = _TypenameWithoutSpreadsAbstractType$ref & ConcreteFragment;
+export type TypenameWithoutSpreadsAbstractType$ref = _TypenameWithoutSpreadsAbstractType$ref & FragmentReference;
 export type TypenameWithoutSpreadsAbstractType = {
     readonly __typename: string;
     readonly id: string;
@@ -655,10 +655,10 @@ export type TypenameWithoutSpreadsAbstractType = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _TypenameWithCommonSelections$ref {
 }
-export type TypenameWithCommonSelections$ref = _TypenameWithCommonSelections$ref & ConcreteFragment;
+export type TypenameWithCommonSelections$ref = _TypenameWithCommonSelections$ref & FragmentReference;
 export type TypenameWithCommonSelections = {
     readonly __typename: string;
     readonly name: string | null;
@@ -700,10 +700,10 @@ fragment AnotherRecursiveFragment on Image {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 type PhotoFragment$ref = any;
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _UserProfile$ref {
 }
-export type UserProfile$ref = _UserProfile$ref & ConcreteFragment;
+export type UserProfile$ref = _UserProfile$ref & FragmentReference;
 export type UserProfile = {
     readonly profilePicture: ({
         readonly uri: string | null;
@@ -715,10 +715,10 @@ export type UserProfile = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _PhotoFragment$ref {
 }
-export type PhotoFragment$ref = _PhotoFragment$ref & ConcreteFragment;
+export type PhotoFragment$ref = _PhotoFragment$ref & FragmentReference;
 export type PhotoFragment = {
     readonly uri: string | null;
     readonly width: number | null;
@@ -726,10 +726,10 @@ export type PhotoFragment = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _RecursiveFragment$ref {
 }
-export type RecursiveFragment$ref = _RecursiveFragment$ref & ConcreteFragment;
+export type RecursiveFragment$ref = _RecursiveFragment$ref & FragmentReference;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
@@ -737,10 +737,10 @@ export type RecursiveFragment = {
 };
 
 
-import { ConcreteFragment } from "relay-runtime";
+import { FragmentReference } from "relay-runtime";
 const enum _AnotherRecursiveFragment$ref {
 }
-export type AnotherRecursiveFragment$ref = _AnotherRecursiveFragment$ref & ConcreteFragment;
+export type AnotherRecursiveFragment$ref = _AnotherRecursiveFragment$ref & FragmentReference;
 export type AnotherRecursiveFragment = {
     readonly uri: string | null;
     readonly height: number | null;

--- a/test/__snapshots__/TypeScriptGenerator-test.ts.snap
+++ b/test/__snapshots__/TypeScriptGenerator-test.ts.snap
@@ -13,23 +13,13 @@ fragment NestedCondition on Node {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { FragmentReference } from "relay-runtime";
-const enum _ConditionField$ref {
-}
-export type ConditionField$ref = _ConditionField$ref & FragmentReference;
 export type ConditionField = {
     readonly id?: string;
-    readonly " $refType": ConditionField$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _NestedCondition$ref {
-}
-export type NestedCondition$ref = _NestedCondition$ref & FragmentReference;
 export type NestedCondition = {
     readonly id?: string;
-    readonly " $refType": NestedCondition$ref;
 };
 
 `;
@@ -66,38 +56,20 @@ fragment ConcreateTypes on Viewer {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-type OtherFragment$ref = any;
-type PictureFragment$ref = any;
-type UserFrag1$ref = any;
-type UserFrag2$ref = any;
-import { FragmentReference } from "relay-runtime";
-const enum _FragmentSpread$ref {
-}
-export type FragmentSpread$ref = _FragmentSpread$ref & FragmentReference;
 export type FragmentSpread = {
     readonly id: string;
     readonly justFrag: ({
-        readonly " $fragmentRefs": PictureFragment$ref;
     }) | null;
     readonly fragAndField: ({
         readonly uri: string | null;
-        readonly " $fragmentRefs": PictureFragment$ref;
     }) | null;
-    readonly " $fragmentRefs": OtherFragment$ref & UserFrag1$ref & UserFrag2$ref;
-    readonly " $refType": FragmentSpread$ref;
 };
 
 
-type PageFragment$ref = any;
-import { FragmentReference } from "relay-runtime";
-const enum _ConcreateTypes$ref {
-}
-export type ConcreateTypes$ref = _ConcreateTypes$ref & FragmentReference;
 export type ConcreateTypes = {
     readonly actor: ({
         readonly __typename: "Page";
         readonly id: string;
-        readonly " $fragmentRefs": PageFragment$ref;
     } | {
         readonly __typename: "User";
         readonly name: string | null;
@@ -106,7 +78,6 @@ export type ConcreateTypes = {
         value in case none of the concrete values match.*/
         readonly __typename: "%other";
     }) | null;
-    readonly " $refType": ConcreateTypes$ref;
 };
 
 `;
@@ -175,24 +146,15 @@ fragment InlineFragmentKitchenSink on Story {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { FragmentReference } from "relay-runtime";
-const enum _InlineFragment$ref {
-}
-export type InlineFragment$ref = _InlineFragment$ref & FragmentReference;
 export type InlineFragment = {
     readonly id: string;
     readonly name?: string | null;
     readonly message?: ({
         readonly text: string | null;
     }) | null;
-    readonly " $refType": InlineFragment$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _InlineFragmentWithOverlappingFields$ref {
-}
-export type InlineFragmentWithOverlappingFields$ref = _InlineFragmentWithOverlappingFields$ref & FragmentReference;
 export type InlineFragmentWithOverlappingFields = {
     readonly hometown?: ({
         readonly id: string;
@@ -202,26 +164,15 @@ export type InlineFragmentWithOverlappingFields = {
         }) | null;
     }) | null;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentWithOverlappingFields$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _InlineFragmentConditionalID$ref {
-}
-export type InlineFragmentConditionalID$ref = _InlineFragmentConditionalID$ref & FragmentReference;
 export type InlineFragmentConditionalID = {
     readonly id?: string;
     readonly name?: string | null;
-    readonly " $refType": InlineFragmentConditionalID$ref;
 };
 
 
-type SomeFragment$ref = any;
-import { FragmentReference } from "relay-runtime";
-const enum _InlineFragmentKitchenSink$ref {
-}
-export type InlineFragmentKitchenSink$ref = _InlineFragmentKitchenSink$ref & FragmentReference;
 export type InlineFragmentKitchenSink = {
     readonly actor: ({
         readonly id: string;
@@ -231,9 +182,7 @@ export type InlineFragmentKitchenSink = {
             readonly height?: number | null;
         }) | null;
         readonly name?: string | null;
-        readonly " $fragmentRefs": SomeFragment$ref;
     }) | null;
-    readonly " $refType": InlineFragmentKitchenSink$ref;
 };
 
 `;
@@ -269,10 +218,6 @@ query UnionTypeTest {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { FragmentReference } from "relay-runtime";
-const enum _LinkedField$ref {
-}
-export type LinkedField$ref = _LinkedField$ref & FragmentReference;
 export type LinkedField = {
     readonly profilePicture: ({
         readonly uri: string | null;
@@ -288,7 +233,6 @@ export type LinkedField = {
     readonly actor: ({
         readonly id: string;
     }) | null;
-    readonly " $refType": LinkedField$ref;
 };
 
 
@@ -382,13 +326,8 @@ fragment PluralFragment on Node @relay(plural: true) {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { FragmentReference } from "relay-runtime";
-const enum _PluralFragment$ref {
-}
-export type PluralFragment$ref = _PluralFragment$ref & FragmentReference;
 export type PluralFragment = ReadonlyArray<{
         readonly id: string;
-        readonly " $refType": PluralFragment$ref;
     }>;
 
 `;
@@ -432,13 +371,8 @@ export type ExampleQueryResponse = {
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _ExampleFragment$ref {
-}
-export type ExampleFragment$ref = _ExampleFragment$ref & FragmentReference;
 export type ExampleFragment = {
     readonly id: string;
-    readonly " $refType": ExampleFragment$ref;
 };
 
 
@@ -491,10 +425,6 @@ fragment ScalarField on User {
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
-import { FragmentReference } from "relay-runtime";
-const enum _ScalarField$ref {
-}
-export type ScalarField$ref = _ScalarField$ref & FragmentReference;
 export type ScalarField = {
     readonly id: string;
     readonly name: string | null;
@@ -507,7 +437,6 @@ export type ScalarField = {
             readonly name: string | null;
             readonly service: string | null;
         }) | null> | null;
-    readonly " $refType": ScalarField$ref;
 };
 
 `;
@@ -576,50 +505,32 @@ fragment TypenameWithCommonSelections on Actor {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameInside$ref {
-}
-export type TypenameInside$ref = _TypenameInside$ref & FragmentReference;
 export type TypenameInside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameInside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameInside$ref;
 } | {
     /*This will never be '% other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameInside$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameOutside$ref {
-}
-export type TypenameOutside$ref = _TypenameOutside$ref & FragmentReference;
 export type TypenameOutside = {
     readonly __typename: "User";
     readonly firstName: string | null;
-    readonly " $refType": TypenameOutside$ref;
 } | {
     readonly __typename: "Page";
     readonly username: string | null;
-    readonly " $refType": TypenameOutside$ref;
 } | {
     /*This will never be '% other', but we need some
     value in case none of the concrete values match.*/
     readonly __typename: "%other";
-    readonly " $refType": TypenameOutside$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameOutsideWithAbstractType$ref {
-}
-export type TypenameOutsideWithAbstractType$ref = _TypenameOutsideWithAbstractType$ref & FragmentReference;
 export type TypenameOutsideWithAbstractType = {
     readonly __typename: string;
     readonly username?: string | null;
@@ -629,42 +540,26 @@ export type TypenameOutsideWithAbstractType = {
         readonly street?: string | null;
     }) | null;
     readonly firstName?: string | null;
-    readonly " $refType": TypenameOutsideWithAbstractType$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameWithoutSpreads$ref {
-}
-export type TypenameWithoutSpreads$ref = _TypenameWithoutSpreads$ref & FragmentReference;
 export type TypenameWithoutSpreads = {
     readonly firstName: string | null;
     readonly __typename: "User";
-    readonly " $refType": TypenameWithoutSpreads$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameWithoutSpreadsAbstractType$ref {
-}
-export type TypenameWithoutSpreadsAbstractType$ref = _TypenameWithoutSpreadsAbstractType$ref & FragmentReference;
 export type TypenameWithoutSpreadsAbstractType = {
     readonly __typename: string;
     readonly id: string;
-    readonly " $refType": TypenameWithoutSpreadsAbstractType$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _TypenameWithCommonSelections$ref {
-}
-export type TypenameWithCommonSelections$ref = _TypenameWithCommonSelections$ref & FragmentReference;
 export type TypenameWithCommonSelections = {
     readonly __typename: string;
     readonly name: string | null;
     readonly firstName?: string | null;
     readonly username?: string | null;
-    readonly " $refType": TypenameWithCommonSelections$ref;
 };
 
 `;
@@ -699,52 +594,30 @@ fragment AnotherRecursiveFragment on Image {
 }
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-type PhotoFragment$ref = any;
-import { FragmentReference } from "relay-runtime";
-const enum _UserProfile$ref {
-}
-export type UserProfile$ref = _UserProfile$ref & FragmentReference;
 export type UserProfile = {
     readonly profilePicture: ({
         readonly uri: string | null;
         readonly width: number | null;
         readonly height: number | null;
-        readonly " $fragmentRefs": PhotoFragment$ref;
     }) | null;
-    readonly " $refType": UserProfile$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _PhotoFragment$ref {
-}
-export type PhotoFragment$ref = _PhotoFragment$ref & FragmentReference;
 export type PhotoFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": PhotoFragment$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _RecursiveFragment$ref {
-}
-export type RecursiveFragment$ref = _RecursiveFragment$ref & FragmentReference;
 export type RecursiveFragment = {
     readonly uri: string | null;
     readonly width: number | null;
-    readonly " $refType": RecursiveFragment$ref;
 };
 
 
-import { FragmentReference } from "relay-runtime";
-const enum _AnotherRecursiveFragment$ref {
-}
-export type AnotherRecursiveFragment$ref = _AnotherRecursiveFragment$ref & FragmentReference;
 export type AnotherRecursiveFragment = {
     readonly uri: string | null;
     readonly height: number | null;
-    readonly " $refType": AnotherRecursiveFragment$ref;
 };
 
 `;

--- a/test/fixtures/generated-module/complete-example.ts
+++ b/test/fixtures/generated-module/complete-example.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 
-import { ConcreteFragment } from 'relay-runtime';
+import { ConcreteFragment } from "relay-runtime";
 export type CompleteExample = { readonly id: string }
 
 


### PR DESCRIPTION
This

* Renames `ConcreteFragment` to `FragmentReference`
* Disables all code related to fragment references until we get to #7

I’m going to self-merge this and cut a 0.9.0 version of the package (we can save v1 for when we have fragment references) so that I can start using that in our app properly.